### PR TITLE
sdm660-common: audio: Back to AUDIO_FORMAT_PCM_16_BIT for primary

### DIFF
--- a/configs/audio/audio_output_policy.conf
+++ b/configs/audio/audio_output_policy.conf
@@ -13,9 +13,9 @@
 outputs {
   default {
     flags AUDIO_OUTPUT_FLAG_PRIMARY
-    formats AUDIO_FORMAT_PCM_24_BIT
+    formats AUDIO_FORMAT_PCM_16_BIT
     sampling_rates 48000
-    bit_width 24
+    bit_width 16
     app_type 69937
   }
   deep_buffer {

--- a/configs/audio/audio_policy_configuration.xml
+++ b/configs/audio/audio_policy_configuration.xml
@@ -53,11 +53,11 @@
             <defaultOutputDevice>Speaker</defaultOutputDevice>
             <mixPorts>
                 <mixPort name="primary output" role="source" flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_PRIMARY">
-                    <profile name="" format="AUDIO_FORMAT_PCM_24_BIT_PACKED"
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
                 <mixPort name="raw" role="source"
-                        flags="AUDIO_OUTPUT_FLAG_FAST">
+                        flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>

--- a/configs/audio/audio_policy_configuration_a2dp_offload_disabled.xml
+++ b/configs/audio/audio_policy_configuration_a2dp_offload_disabled.xml
@@ -53,11 +53,11 @@
             <defaultOutputDevice>Speaker</defaultOutputDevice>
             <mixPorts>
                 <mixPort name="primary output" role="source" flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_PRIMARY">
-                    <profile name="" format="AUDIO_FORMAT_PCM_24_BIT_PACKED"
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
                 <mixPort name="raw" role="source"
-                        flags="AUDIO_OUTPUT_FLAG_FAST">
+                        flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
@@ -305,7 +305,7 @@
 
         <!-- A2DP Input Audio HAL -->
         <xi:include href="/vendor/etc/a2dp_in_audio_policy_configuration.xml"/>
-        
+
         <!-- Bluetooth Audio HAL -->
         <xi:include href="/vendor/etc/bluetooth_audio_policy_configuration.xml"/>
 

--- a/configs/audio/audio_policy_configuration_a2dp_offload_disabled_qti.xml
+++ b/configs/audio/audio_policy_configuration_a2dp_offload_disabled_qti.xml
@@ -53,11 +53,11 @@
             <defaultOutputDevice>Speaker</defaultOutputDevice>
             <mixPorts>
                 <mixPort name="primary output" role="source" flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_PRIMARY">
-                    <profile name="" format="AUDIO_FORMAT_PCM_24_BIT_PACKED"
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
                 <mixPort name="raw" role="source"
-                        flags="AUDIO_OUTPUT_FLAG_FAST">
+                        flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>


### PR DESCRIPTION
ゲーム (というか音ゲ) のレイテンシがやたらでかいのを改善…というか、もとに戻します。

一部 A2DP 周りの改善？と一緒にあたっていた部分があるので、
これを一部戻すことによって BT Audio への影響があるかもしれませんが、
うちではテスト出来ないのでしていません。

https://github.com/mordiford/device_xiaomi_sdm660-common/commit/6d0c348b2c5ff594faa759f5f4d2e84a2089460d#diff-060d88aa23f3f46c3f638c4c71da8e63
https://github.com/mordiford/device_xiaomi_sdm660-common/commit/cd5d5cb490a6210293cc9e78338ae060e4fcc4bf#diff-060d88aa23f3f46c3f638c4c71da8e63

できれば BT 周りをテストしていただけると助かります。
